### PR TITLE
Add password and number layout support

### DIFF
--- a/demo/src/main/java/io/asfjava/ui/demo/screen/DemoForm.java
+++ b/demo/src/main/java/io/asfjava/ui/demo/screen/DemoForm.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import io.asfjava.ui.core.form.ComboBox;
 import io.asfjava.ui.core.form.TextArea;
 import io.asfjava.ui.core.form.TextField;
+import io.asfjava.ui.core.form.Password;
 
 public class DemoForm implements Serializable {
 
@@ -13,12 +14,17 @@ public class DemoForm implements Serializable {
 
 	@TextField(title = "Last Name", placeHolder = "Your last name")
 	private String lastName;
-
+	
+	@Password(title = "Password", placeHolder = "Please set you password", description = "This is password")
+	private String password;
+	
 	@ComboBox(title = "Gender", values = { "Male", "Female" })
 	private String gender;
 
 	@TextArea(title = "Address", placeHolder = "Fill your address please", description = "This is textarea")
 	private String address;
+	
+
 
 	public String getFirstName() {
 		return firstName;
@@ -36,6 +42,14 @@ public class DemoForm implements Serializable {
 		this.lastName = lastName;
 	}
 
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+	
 	public String getGender() {
 		return gender;
 	}

--- a/demo/src/main/java/io/asfjava/ui/demo/screen/DemoForm.java
+++ b/demo/src/main/java/io/asfjava/ui/demo/screen/DemoForm.java
@@ -6,6 +6,7 @@ import io.asfjava.ui.core.form.ComboBox;
 import io.asfjava.ui.core.form.TextArea;
 import io.asfjava.ui.core.form.TextField;
 import io.asfjava.ui.core.form.Password;
+import io.asfjava.ui.core.form.Number;
 
 public class DemoForm implements Serializable {
 
@@ -14,6 +15,9 @@ public class DemoForm implements Serializable {
 
 	@TextField(title = "Last Name", placeHolder = "Your last name")
 	private String lastName;
+	
+	@Number(title = "Phone Number", placeHolder = "Your phone number", description = "This is a number")
+	private Integer number;
 	
 	@Password(title = "Password", placeHolder = "Please set you password", description = "This is password")
 	private String password;
@@ -42,6 +46,14 @@ public class DemoForm implements Serializable {
 		this.lastName = lastName;
 	}
 
+	public Integer getNumber() {
+		return number;
+	}
+
+	public void setNumber(Integer number) {
+		this.number = number;
+	}
+	
 	public String getPassword() {
 		return password;
 	}

--- a/src/main/java/io/asfjava/ui/core/form/Number.java
+++ b/src/main/java/io/asfjava/ui/core/form/Number.java
@@ -1,0 +1,23 @@
+package io.asfjava.ui.core.form;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface Number {
+	String title();
+
+	String placeHolder() default "";
+
+	String description() default "";
+
+	boolean noTitle() default false;
+
+	String validationMessage() default "";
+
+	boolean readOnly() default false;
+}

--- a/src/main/java/io/asfjava/ui/core/form/Password.java
+++ b/src/main/java/io/asfjava/ui/core/form/Password.java
@@ -1,0 +1,23 @@
+package io.asfjava.ui.core.form;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface Password {
+	String title();
+
+	String placeHolder() default "";
+
+	String description() default "";
+
+	boolean noTitle() default false;
+
+	String validationMessage() default "";
+
+	boolean readOnly() default false;
+}

--- a/src/main/java/io/asfjava/ui/core/generators/NumberGenerator.java
+++ b/src/main/java/io/asfjava/ui/core/generators/NumberGenerator.java
@@ -1,0 +1,45 @@
+package io.asfjava.ui.core.generators;
+
+import java.lang.reflect.Field;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.asfjava.ui.core.form.Number;
+
+public class NumberGenerator implements FormDefinitionGenerator {
+
+	@Override
+	public void generate(ObjectNode fieldFormDefinition, Field field) {
+		Number annotation = field.getAnnotation(Number.class);
+		fieldFormDefinition.put("key", field.getName());
+		fieldFormDefinition.put("label", annotation.title());
+		fieldFormDefinition.put("type", "number");
+
+		String description = annotation.description();
+		if (!description.isEmpty()) {
+			fieldFormDefinition.put("description", description);
+		}
+		String placeHolder = annotation.placeHolder();
+		if (!placeHolder.isEmpty()) {
+			fieldFormDefinition.put("placeholder", placeHolder);
+		}
+		boolean noTitle = annotation.noTitle();
+		if (noTitle) {
+			fieldFormDefinition.put("notitle", noTitle);
+		}
+		String validationMessage = annotation.validationMessage();
+		if (!validationMessage.isEmpty()) {
+			fieldFormDefinition.put("validationMessage", validationMessage);
+		}
+		boolean readOnly = annotation.readOnly();
+		if (readOnly) {
+			fieldFormDefinition.put("readonly", readOnly);
+		}
+	}
+
+	@Override
+	public String getAnnoation() {
+		return Number.class.getName();
+	}
+
+}

--- a/src/main/java/io/asfjava/ui/core/generators/PasswordGenerator.java
+++ b/src/main/java/io/asfjava/ui/core/generators/PasswordGenerator.java
@@ -1,0 +1,45 @@
+package io.asfjava.ui.core.generators;
+
+import java.lang.reflect.Field;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.asfjava.ui.core.form.Password;
+
+public class PasswordGenerator implements FormDefinitionGenerator {
+
+	@Override
+	public void generate(ObjectNode fieldFormDefinition, Field field) {
+		Password annotation = field.getAnnotation(Password.class);
+		fieldFormDefinition.put("key", field.getName());
+		fieldFormDefinition.put("label", annotation.title());
+		fieldFormDefinition.put("type", "password");
+
+		String description = annotation.description();
+		if (!description.isEmpty()) {
+			fieldFormDefinition.put("description", description);
+		}
+		String placeHolder = annotation.placeHolder();
+		if (!placeHolder.isEmpty()) {
+			fieldFormDefinition.put("placeholder", placeHolder);
+		}
+		boolean noTitle = annotation.noTitle();
+		if (noTitle) {
+			fieldFormDefinition.put("notitle", noTitle);
+		}
+		String validationMessage = annotation.validationMessage();
+		if (!validationMessage.isEmpty()) {
+			fieldFormDefinition.put("validationMessage", validationMessage);
+		}
+		boolean readOnly = annotation.readOnly();
+		if (readOnly) {
+			fieldFormDefinition.put("readonly", readOnly);
+		}
+	}
+
+	@Override
+	public String getAnnoation() {
+		return Password.class.getName();
+	}
+
+}

--- a/src/main/java/io/asfjava/ui/core/schema/CustomStringSchema.java
+++ b/src/main/java/io/asfjava/ui/core/schema/CustomStringSchema.java
@@ -9,8 +9,10 @@ import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
 
 import io.asfjava.ui.core.form.ComboBox;
+import io.asfjava.ui.core.form.Password;
 import io.asfjava.ui.core.form.TextArea;
 import io.asfjava.ui.core.form.TextField;
+import io.asfjava.ui.core.form.Number;
 
 class CustomStringSchema extends StringSchema {
 	@JsonProperty
@@ -33,6 +35,14 @@ class CustomStringSchema extends StringSchema {
 		TextArea textArea = beanProperty.getAnnotation(TextArea.class);
 		if (textArea != null) {
 			this.setTitle(textArea.title());
+		}
+		Password password = beanProperty.getAnnotation(Password.class);
+		if (password != null) {
+			this.setTitle(password.title());
+		}
+		Number number = beanProperty.getAnnotation(Number.class);
+		if (number != null) {
+			this.setTitle(number.title());
 		}
 	}
 


### PR DESCRIPTION
### Description

Add the password and number layout

### Modifications

1. Add new @password annotation with appropriate fields
2. Implement the PasswordGenerator
3. Improve the demo app to support the password layout

4. Add new @number annotation with appropriate fields
5. Implement the NumberGenerator
6. Improve the demo app to support the number layout

**Expected behavior:** Support the password and number layout
