### PR TITLE
In order to support the loading of addons generators and decorators.

### DIFF
--- a/src/main/java/io/asfjava/ui/core/GeneratorFactoryLoader.java
+++ b/src/main/java/io/asfjava/ui/core/GeneratorFactoryLoader.java
@@ -2,22 +2,30 @@ package io.asfjava.ui.core;
 
 import static io.asfjava.ui.core.logging.ErrorCode.ASF01;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.reflections.Reflections;
 
 import io.asfjava.ui.core.generators.FormDefinitionGenerator;
 import io.asfjava.ui.core.logging.ASFUILogger;
 
 final class GeneratorFactoryLoader {
-	private static final String PACKAGESCAN = "io.asfjava.ui.core.generators";
+	private static final List<String> PACKAGESCAN = Stream
+			.of("io.asfjava.ui.core.generators", "io.asfjava.ui.addons.generators").collect(Collectors.toList());
 	private static Reflections reflections = new Reflections(PACKAGESCAN);
 
 	void load() {
-		reflections.getSubTypesOf(FormDefinitionGenerator.class).stream().forEach(subtype -> register(subtype));
+		for (Class<? extends FormDefinitionGenerator> subType : reflections
+				.getSubTypesOf(FormDefinitionGenerator.class)) {
+			register(subType);
+		}
 	}
 
-	private void register(Class<? extends FormDefinitionGenerator> subtype) {
+	private void register(Class<? extends FormDefinitionGenerator> subType) {
 		try {
-			FormDefinitionGenerator formDefinitionGenerator = subtype.newInstance();
+			FormDefinitionGenerator formDefinitionGenerator = subType.newInstance();
 			FormDefinitionGeneratorFactory.getInstance().register(formDefinitionGenerator::getAnnotation,
 					formDefinitionGenerator);
 		} catch (InstantiationException | IllegalAccessException e) {

--- a/src/main/java/io/asfjava/ui/core/SchemaDecoratorLoader.java
+++ b/src/main/java/io/asfjava/ui/core/SchemaDecoratorLoader.java
@@ -2,6 +2,10 @@ package io.asfjava.ui.core;
 
 import static io.asfjava.ui.core.logging.ErrorCode.ASF01;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.reflections.Reflections;
 
 import io.asfjava.ui.core.logging.ASFUILogger;
@@ -9,16 +13,20 @@ import io.asfjava.ui.core.schema.decorators.SchemaDecorator;
 
 final class SchemaDecoratorLoader {
 
-	private static final String PACKAGESCAN = "io.asfjava.ui.core.schema.decorators";
+	private static final List<String> PACKAGESCAN = Stream
+			.of("io.asfjava.ui.core.schema.decorators", "io.asfjava.ui.addons.schema.decorators")
+			.collect(Collectors.toList());
 	private static Reflections reflections = new Reflections(PACKAGESCAN);
 
 	void load() {
-		reflections.getSubTypesOf(SchemaDecorator.class).stream().forEach(subtype -> register(subtype));
+		for (Class<? extends SchemaDecorator> subType : reflections.getSubTypesOf(SchemaDecorator.class)) {
+			register(subType);
+		}
 	}
 
-	private void register(Class<? extends SchemaDecorator> subtype) {
+	private void register(Class<? extends SchemaDecorator> subType) {
 		try {
-			SchemaDecorator decorator = subtype.newInstance();
+			SchemaDecorator decorator = subType.newInstance();
 			SchemaDecoratorFactory.getInstance().register(decorator::getAnnotation, decorator);
 		} catch (InstantiationException | IllegalAccessException e) {
 			ASFUILogger.getLogger().error(ASF01, e);
@@ -30,12 +38,12 @@ final class SchemaDecoratorLoader {
 	}
 
 	static SchemaDecoratorLoader getInstance() {
-		if (INSTANCE == null)
-			INSTANCE = new SchemaDecoratorLoader();
-		return INSTANCE;
+		if (instance == null)
+			instance = new SchemaDecoratorLoader();
+		return instance;
 	}
 
-	private static SchemaDecoratorLoader INSTANCE;
+	private static SchemaDecoratorLoader instance;
 
 	private SchemaDecoratorLoader() {
 	}

--- a/src/main/java/io/asfjava/ui/core/generators/CheckBoxGenerator.java
+++ b/src/main/java/io/asfjava/ui/core/generators/CheckBoxGenerator.java
@@ -40,15 +40,18 @@ public class CheckBoxGenerator implements FormDefinitionGenerator{
 				fieldFormDefinition.set("titleMap", titlesMap);
 			} catch (InstantiationException | IllegalAccessException e) {
 				ASFUILogger.getLogger().error(e.getMessage());
+				throw new RuntimeException(e);
 			}
 		}
 	}
 
 	private void buildValueDefinition(ObjectMapper checkBoxMapper, ArrayNode titlesMap, String value) {
 		ObjectNode entry = checkBoxMapper.createObjectNode();
-		if (value.equals(value.toUpperCase())) {
+		String upperCasedValue = value.toUpperCase();
+		String lowerCasedValue = value.toLowerCase();
+		if (value.equals(upperCasedValue)) {
 			entry.put("name", value.toLowerCase());
-		} else if (value.equals(value.toLowerCase())) {
+		} else if (value.equals(lowerCasedValue)) {
 			entry.put("name", value.replace(value.substring(0, 1), value.substring(0, 1).toUpperCase()));
 		} else {
 			entry.put("name", value);

--- a/src/main/java/io/asfjava/ui/core/generators/ComboBoxGenerator.java
+++ b/src/main/java/io/asfjava/ui/core/generators/ComboBoxGenerator.java
@@ -44,6 +44,7 @@ public class ComboBoxGenerator implements FormDefinitionGenerator {
 				fieldFormDefinition.set("titleMap", titlesMap);
 			} catch (InstantiationException | IllegalAccessException e) {
 				ASFUILogger.getLogger().error(e.getMessage());
+				throw new RuntimeException(e);
 			}
 		}
 
@@ -51,9 +52,11 @@ public class ComboBoxGenerator implements FormDefinitionGenerator {
 
 	private void buildValueDefinition(ObjectMapper comboMapper, ArrayNode titlesMap, String value) {
 		ObjectNode entry = comboMapper.createObjectNode();
-		if (value.equals(value.toUpperCase())) {
+		String upperCasedValue = value.toUpperCase();
+		String lowerCasedValue = value.toLowerCase();
+		if (value.equals(upperCasedValue)) {
 			entry.put("name", value.toLowerCase());
-		} else if (value.equals(value.toLowerCase())) {
+		} else if (value.equals(lowerCasedValue)) {
 			entry.put("name", value.replace(value.substring(0, 1), value.substring(0, 1).toUpperCase()));
 		} else {
 			entry.put("name", value);

--- a/src/main/java/io/asfjava/ui/core/generators/RadioBoxGenerator.java
+++ b/src/main/java/io/asfjava/ui/core/generators/RadioBoxGenerator.java
@@ -21,7 +21,7 @@ public class RadioBoxGenerator implements FormDefinitionGenerator {
 		fieldFormDefinition.put("readOnly", annotation.readOnly());
 		fieldFormDefinition.put("type", "radios");
 
-		JsonNode radioFieldFormDefinition = ((JsonNode) fieldFormDefinition);
+		JsonNode radioFieldFormDefinition = fieldFormDefinition;
 
 		ObjectMapper radioMapper = new ObjectMapper();
 
@@ -41,6 +41,7 @@ public class RadioBoxGenerator implements FormDefinitionGenerator {
 			}
 		} catch (InstantiationException | IllegalAccessException e) {
 			ASFUILogger.getLogger().error(e.getMessage());
+			throw new RuntimeException(e);
 		}
 
 		((ObjectNode) radioFieldFormDefinition).set("titleMap", titlesMap);

--- a/src/main/java/io/asfjava/ui/core/logging/ASFUILogger.java
+++ b/src/main/java/io/asfjava/ui/core/logging/ASFUILogger.java
@@ -9,4 +9,8 @@ public final class ASFUILogger {
 	public static Logger getLogger(){
 		return LOGGER;
 	}
+	
+	private ASFUILogger() {
+	}
+
 }

--- a/src/main/java/io/asfjava/ui/core/schema/UiFormSchemaGenerator.java
+++ b/src/main/java/io/asfjava/ui/core/schema/UiFormSchemaGenerator.java
@@ -17,7 +17,7 @@ import io.asfjava.ui.dto.UiForm;
 
 public final class UiFormSchemaGenerator {
 
-	private static UiFormSchemaGenerator INSTANCE;
+	private static UiFormSchemaGenerator instance;
 
 	public UiForm generate(Class<? extends Serializable> formDto) throws JsonMappingException {
 		ObjectMapper mapper = new ObjectMapper();
@@ -47,10 +47,10 @@ public final class UiFormSchemaGenerator {
 	}
 
 	public static UiFormSchemaGenerator get() {
-		if (INSTANCE == null) {
-			INSTANCE = new UiFormSchemaGenerator();
+		if (instance == null) {
+			instance = new UiFormSchemaGenerator();
 		}
-		return INSTANCE;
+		return instance;
 	}
 
 	private UiFormSchemaGenerator() {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
* Support the loading of addons generators and decorators.  …
* All sonar violations removed.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
